### PR TITLE
Fix param size (uint16_t)

### DIFF
--- a/gpu/include/cricket-types.h
+++ b/gpu/include/cricket-types.h
@@ -59,7 +59,7 @@ typedef struct _cricket_param_info
     uint16_t index;
     uint16_t ordinal;
     uint16_t offset;
-    uint8_t size;
+    uint16_t size;
 } cricket_param_info;
 
 typedef struct _cricket_elf_info

--- a/gpu/src/cricket-elf.c
+++ b/gpu/src/cricket-elf.c
@@ -381,7 +381,7 @@ bool cricket_elf_get_info(const char *function_name, cricket_elf_info *info)
                     info->params[i].index = *(uint16_t *)(attrs + 4 + i * 12);
                     info->params[i].offset = *(uint16_t *)(attrs + 6 + i * 12);
                     info->params[i].size =
-                        *(uint8_t *)(attrs + 10 + i * 12) >> 2;
+                        *(uint16_t *)(attrs + 10 + i * 12) >> 2;
                 }
                 free(attrs);
                 if (!cricket_elf_extract_attribute((*objfile)->obfd, section,


### PR DESCRIPTION
Hi, I needed to get the parameters of cuda kernels for a unrelated project and fortunately found this wonderful project.

I used [this](https://github.com/RWTH-ACS/cricket/blob/master/gpu/src/cricket-elf.c#L144) code as inspiration.

It seemingly worked great but I had some issues for certain kernels and I tracked it down to the size being 0x0 when it should be 0x140.
After debugging the cuobjdump binary I found that the size is actually 16 bit.

As I am not actually using this project I don't know if any changes in other places are required, but I still wanted to contribute this in case it affects anybody else.